### PR TITLE
fixes in hilbert

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -74,3 +74,32 @@ fftpack
    fftpack.idct
    fftpack.dst
    fftpack.idst
+
+Spectral (FFT) analysis
+=======================
+
+.. autosummary::
+   :toctree: generated/
+
+   signal.csd
+   signal.psd
+   signal.coherence
+   signal.xcorrelation
+   signal.crossspectrogram
+   signal.spectrogram
+   signal.coherogram
+   signal.hilbert
+
+Digital filters
+===============
+
+.. autosummary::
+   :toctree: generated/
+
+   signal.frequency_filter
+   signal.lowpass
+   signal.highpass
+   signal.bandpass
+   signal.bandstop
+   signal.decimate
+   signal.savgol_filter

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,7 +40,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.extlinks',
     'sphinx.ext.mathjax',
-    'numpydoc',
+    'sphinx.ext.napoleon',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
 ]
@@ -304,5 +304,6 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
-    'xarray': ('http://xarray.pydata.org/', None),
+    'xarray': ('http://xarray.pydata.org/en/stable', None),
+    'scipy':  ('https://docs.scipy.org/doc/scipy/reference', None),
 }

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,16 +1,12 @@
 name: xr-scipy-docs
 channels:
-  - conda-forge
   - defaults
 dependencies:
-  - python=3.6
-  - numpy=1.13
-  - pandas=0.21.0
+  - python=3.7
+  - numpy
   - xarray
-  - scipy=1.0
-  - numpydoc=0.7.0
-  - matplotlib=2.1.2
-  - ipython=6.2.1
-  - sphinx=1.5
-  - sphinx-gallery
+  - scipy
+  - matplotlib
+  - ipython
+  - sphinx
   - flake8

--- a/doc/fft.rst
+++ b/doc/fft.rst
@@ -22,26 +22,28 @@ Let us consider an example DataArray
                        dims=('x'), coords={'x': np.linspace(0, 5, 30)})
     arr
 
-Our :py:func:`~xrscipy.fft.rfft` takes an xarray object
+Our :py:func:`~xrscipy.fft.fft` takes an xarray object
 (possibly high dimensional) and a coordinate name which direction we compute
 the Fourier transform.
 
 .. ipython:: python
 
-    rfft = xrscipy.fft.rfft(arr, 'x')
-    rfft
+    fft = xrscipy.fft.fft(arr, 'x')
+    fft
 
 The coordinate `x` is also converted to frequency.
 
 .. ipython:: python
+    :okwarning:
 
     plt.figure(figsize=(10, 4))
     plt.subplot(1, 2, 1)
     arr.plot()
     plt.subplot(1, 2, 2)
-    np.abs(rfft).plot()
-    @savefig rfft.png width=4in
+    np.abs(fft).plot()
+    @savefig fft.png width=4in
     plt.show()
+
 
 .. note::
 
@@ -67,6 +69,7 @@ coordinates.
     fftn
 
 .. ipython:: python
+    :okwarning:
 
     plt.figure(figsize=(10, 4))
     plt.subplot(1, 2, 1)

--- a/doc/filters.rst
+++ b/doc/filters.rst
@@ -1,0 +1,131 @@
+.. _filters:
+
+Digital filters
+---------------
+
+.. ipython:: python
+   :suppress:
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    import xarray as xr
+    import xrscipy.signal as dsp
+
+
+``xr-scipy`` wraps some of SciPy functions for constructing  frequency filters using functions such as :py:func:`scipy.signal.firwin` and  :py:func:`scipy.signal.iirfilter`. Wrappers for convenient functions such as  :py:func:`scipy.signal.decimate` and :py:func:`scipy.signal.savgol_filter` are also provided.
+For convenience, the ``xrscipy.signal`` namespace will be imported under the alias ``dsp``
+
+.. ipython:: python
+
+    import xrscipy.signal as dsp
+
+
+Frequency filters
+^^^^^^^^^^^^^^^^^
+
+The main wrapper for frequency filters is the :py:func:`~xrscipy.signal.frequency_filter` wrapper. It's many arguments enable one to specify the type of filter, e.g. frequency band, FIR or IIR, response type family, filter order, forward-backward filtering, etc. By default a Butterworth IIR 4-th order filter with second-order-series (numerically stable even for high orders) forward-backward application (zero phase shift, but double order) is used, because such a filter typically offers a good performance for most time-series analysis applications.
+
+Convenience functions such as :py:func:`~xrscipy.signal.lowpass`, :py:func:`~xrscipy.signal.highpass` and :py:func:`~xrscipy.signal.bandpass` are provided which wrap :py:func:`~xrscipy.signal.frequency_filter` with a predefined response type and offer a more convenient interface for the cutoff frequency specification.
+
+The cutoff frequency is specified in the inverse usint to the filtered dimension's coordinates (typically time). The wrapper automatically checks the sampling of those coordinates and normalizes the supplied frequency by the Nyquist frequency.
+
+In the following example a simple low-pass filter is applied to a noisy signal. Because the cutoff frequency is close to 0 (relative to the Nyquist frequency) a high filter order is used for sufficient noise attenuation.
+
+
+.. ipython:: python
+    :okwarning:
+
+    t = np.linspace(0, 1, 1000)  # seconds
+    sig = xr.DataArray(np.sin(16*t) + np.random.normal(0, 0.1, t.size),
+                       coords=[('time', t)], name='signal')
+    sig.plot(label='noisy')
+    low = dsp.lowpass(sig, 20, order=8)  # cutoff at 20 Hz
+    low.plot(label='lowpass', linewidth=5)
+    plt.legend()
+    @savefig freq_filters.png width=4in
+    plt.show()
+
+
+Decimation
+^^^^^^^^^^
+
+
+To demonstrate basic functionality of :py:func:`~xrscipy.signal.decimate`, let's create a simple example DataArray:
+
+.. ipython:: python
+
+    arr = xr.DataArray(np.sin(np.linspace(0, 6.28, 300)) ** 2,
+                       dims=('x'), coords={'x': np.linspace(0, 5, 300)})
+    arr
+
+Our :py:func:`~xrscipy.signal.decimate` takes an xarray object
+(possibly high dimensional) and a dimension name (if not 1D)
+along which the signal should be decimated. Decimation means
+
+1. Apply a lowpass filter to remove frequencies above the new Nyquist frequency in order to prevent aliasing
+2. Take every `q`-th point
+
+.. ipython:: python
+
+    arr_decimated = dsp.decimate(arr, q=40)
+    arr_decimated
+
+An alternative parameter to ``q`` is ``target_fs`` which is the new target sampling frequency to obtain, ``q = np.rint(current_fs / target_fs)``.
+
+The return type is also a DataArray with coordinates.
+
+.. ipython:: python
+    :okwarning:
+
+    arr.plot(label='arr', color='r')
+    arr_decimated.plot.line('s--', label='decimated', color='b')
+    plt.legend()
+    @savefig decimated_signal.png width=4in
+    plt.show()
+
+The other keyword arguments are passed on to :py:func:`~xrscipy.signal.lowpass`.
+
+
+Savitzky-Golay LSQ filtering
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Savitzky-Golay filter as a special type of a FIR filter which is equivalent to replacing filtered values by leas-square fits of polynomials (or their derivatives) of a given order within a rolling window. For details see `their Wikipedia page`_ Such a filter is very useful when temporal or spatial features in the signal are of greater interest than frequency or wavenumber bands, respectively.
+
+.. _`their Wikipedia page`: https://en.wikipedia.org/wiki/Savitzky%E2%80%93Golay_filter
+
+To demonstrate basic functionality of :py:func:`~xrscipy.signal.savgol_filter`, let's create a simple example DataArray of the quadratic shape and add some noise:
+
+.. ipython:: python
+
+    arr = xr.DataArray(np.linspace(0, 5, 50) ** 2,
+                       dims=('x'), coords={'x': np.linspace(0, 5, 50)})
+    noise = np.random.normal(0,3,50)
+    arr_noisy = arr + noise
+    arr
+
+Our :py:func:`~xrscipy.signal.savgol_filter` takes an xarray object
+(possibly high dimensional) and a dimension name (if not 1D)
+along which the signal should be filtered.
+The window length is given in the units of the dimension coordinates.
+
+.. ipython:: python
+
+    arr_savgol2 = dsp.savgol_filter(arr_noisy, 2, 2)
+    arr_savgol5 = dsp.savgol_filter(arr_noisy, 5, 2)
+    arr_savgol2
+    arr_savgol5
+
+The return type is also a DataArray with coordinates.
+
+.. ipython:: python
+    :okwarning:
+
+    arr.plot(label='arr', color='r')
+    arr_noisy.plot.line('s', label='nosiy and decimated', color='b')
+    arr_savgol2.plot(label='quadratic fit on 2 units of x', color='k', linewidth=2)
+    arr_savgol5.plot.line('--',label='quadratic fit on 5 units of x', linewidth=2, color='lime')
+    plt.legend()
+    @savefig savgol_signal.png width=4in
+    plt.show()
+
+The other options (polynomial and derivative order) are the same as for :py:func:`scipy.signal.savgol_filter`, see :py:func:`~xrscipy.signal.savgol_filter` for details.

--- a/doc/grad_integ.rst
+++ b/doc/grad_integ.rst
@@ -34,6 +34,7 @@ which direction we compute the gradient of the array,
 The return type is also a DataArray with coordinates.
 
 .. ipython:: python
+    :okwarning:
 
     arr.plot(label='arr')
     grad.plot(label='gradient')
@@ -51,6 +52,7 @@ along which the array to be integrated.
 The return type is also a DataArray,
 
 .. ipython:: python
+    :okwarning:
 
     # trapz computes definite integration
     xrscipy.integrate.trapz(arr, coord='x')
@@ -65,9 +67,6 @@ The return type is also a DataArray,
     @savefig cumtrapz.png width=4in
     plt.show()
 
-
-
-.. ipython:: python
 
 
 See :py:func:`~xrscipy.integrate.trapz` for other options.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,6 +22,8 @@ Documentation
 * :doc:`grad_integ`
 * :doc:`fft`
 * :doc:`interpolate`
+* :doc:`filters`
+* :doc:`spectral`
 
 .. toctree::
    :maxdepth: 1
@@ -31,6 +33,8 @@ Documentation
    grad_integ
    fft
    interpolate
+   filters
+   spectral
 
 **Help & reference**
 

--- a/doc/spectral.rst
+++ b/doc/spectral.rst
@@ -1,0 +1,137 @@
+.. _spectral:
+
+Spectral (FFT) analysis
+-----------------------
+
+.. ipython:: python
+   :suppress:
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    import xarray as xr
+    import xrscipy.signal as dsp
+
+
+xr-scipy wraps some of scipy spectral analysis functions such as :py:func:`scipy.signal.spectrogram`, :py:func:`scipy.signal.csd` etc. For convenience, the ``xrscipy.signal`` namespace will be imported under the alias ``dsp``
+
+.. ipython:: python
+
+    import xrscipy.signal as dsp
+
+To demonstrate the basic functionality, let's create two simple example DataArray at a similar frequency but one with a frequency drift and some noise:
+
+.. ipython:: python
+
+    time_ax = np.arange(0,100,0.01)
+    sig_1 = xr.DataArray(np.sin(100 * time_ax) + np.random.rand(len(time_ax))*3,
+                         coords=[("time", time_ax)], name='sig_1')
+    sig_2 = xr.DataArray((np.cos(100 * time_ax) + np.random.rand(len(time_ax))*3 + 
+                          3*np.sin(30 * time_ax**1.3)),
+                         coords=[("time", time_ax)], name='sig_2')
+
+
+Power spectra
+^^^^^^^^^^^^^
+
+The :py:func:`~xrscipy.signal.spectrogram` function can be used directly on an xarray
+DataArray object. The returned object is again an ``xarray.DataArray`` object.
+
+.. ipython:: python
+
+    spec_1 = dsp.spectrogram(sig_1)
+    spec_2 = dsp.spectrogram(sig_2)
+    spec_2
+
+The ``frequency`` dimension coords are based on the transformed dimension (``time`` in this case) coords sampling (i.e. inverse units). When the signal is 1D, the dimension does not have to be provided.
+
+
+.. ipython:: python
+    :okwarning:
+
+    norm = plt.matplotlib.colors.LogNorm()
+    plt.subplot(211)
+    spec_1.plot(norm=norm)
+    plt.subplot(212)
+    spec_2.plot(norm=norm)
+    @savefig spectrograms.png width=4in
+    plt.show()
+
+
+These routines calculate the FFT on  segments of the signal of a length controlled by ``nperseg`` and ``nfft`` parameters. The routines here offer a convenience parameter ``seglen`` which makes it possible to specify the segment length in the units of the transformed dimension's coords. If ``seglen`` is specified, ``nperseg`` is then calculated from it and ``nfft`` is set using ``scipy.fftpack.next_fast_len`` (or to closest higher power of 2). A desired frequency resolution spacing ``df`` can be achieved by specifying ``seglen=1/df``.
+
+Another convenience parameter is ``overlap_ratio`` which calculates the ``noverlap`` parameter (by how many points the segments overlap) as ``noverlap = np.rint(overlap_ratio * nperseg)``
+
+For example, these parameters calculate the spectrogram with a higher frequency resolution and try to make for the longer segments by overlapping them by 75%.
+
+.. ipython:: python
+
+    dsp.spectrogram(sig_1, seglen=1, overlap_ratio=0.75)
+
+All the functions can be calculated on N-dimensional signals if the dimension is provided. Here the power spectral density (PSD) :math:`P_{xx}` is calculated using Welch's method (i.e. time average of the spectrogram) is shown
+
+
+.. ipython:: python
+
+    sig_2D = xr.concat([sig_1,sig_2], dim="sigs")
+    psd_2D = dsp.psd(sig_2D, dim="time")
+
+.. ipython:: python
+    :okwarning:
+
+    psd_2D.plot.line(x='frequency')
+    plt.loglog()
+    plt.grid(which='both')
+    @savefig psd.png width=4in
+    plt.show()
+
+Cross-coherence and correlation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The same windowed FFT approach is also used to calculate the cross-spectral density :math:`P_{xy}` (using :py:func:`xrscipy.signal.csd`) and from it coherency :math:`\gamma` as
+
+.. math::
+
+    \gamma = \frac{\langle P_{xy}\rangle}{\sqrt{\langle P_{xx} \rangle \langle P_{yy} \rangle}}
+
+where :math:`\langle \dots \rangle` is an average over the FFT windows, i.e. ergodicity is assumed.
+
+.. ipython:: python
+
+    coher_12 = dsp.coherence(sig_1, sig_2)
+    coher_12[:10]
+
+The returned :math:`\gamma` :py:class:`~xarray.DataArray` is complex (because so is :math:`P_{xy}`) and the modulus is what is more commonly called coherence and the angle is the phase shift.
+
+
+.. ipython:: python
+    :okwarning:
+
+    coh = np.abs(coher_12)
+    xphase = xr.apply_ufunc(np.angle, coher_12) / np.pi
+    fig, axs = plt.subplots(2, 1, sharex=True)
+    coh.plot(ax=axs[0])
+    xphase.where(coh > 0.6).plot.line('o--', ax=axs[1])
+    axs[1].set(yticks=[-1, -0.5, 0, 0.5, 1]);
+    @savefig coher.png width=4in
+    plt.show()
+
+
+In the future more convenient wrappers returning the coherence magnitude and cross-phase might be developed.
+
+The cross-correlation is calculated similarly as :math:`\gamma`, but with :math:`\mathcal{F}^{-1} [\langle P_*\rangle ]`, i.e. in the inverse-FFT domain. The ``lag`` coordinates are the inverse of the ``frequency`` coordinates.
+
+
+.. ipython:: python
+    :okwarning:
+
+    xcorr_12 = dsp.xcorrelation(sig_1, sig_2)
+    xcorr_12.loc[-0.1:0.1].plot()
+    plt.grid()
+    @savefig xcorr.png width=4in
+    plt.show()
+
+
+A partially averaged counterpart to :py:func:`~xrscipy.signal.coherence` is :py:func:`~xrscipy.signal.coherogram` which uses a running average over ``nrolling`` FFT windows.
+
+
+

--- a/xrscipy/signal/__init__.py
+++ b/xrscipy/signal/__init__.py
@@ -1,0 +1,2 @@
+from .filters import *
+from .spectral import *

--- a/xrscipy/signal/filters.py
+++ b/xrscipy/signal/filters.py
@@ -1,0 +1,434 @@
+import warnings
+import xarray
+import scipy.signal
+import numpy as np
+
+try:
+    from scipy.signal import sosfiltfilt
+except ImportError:
+    sosfiltfilt = None
+
+from .utils import get_sampling_step, get_maybe_only_dim
+
+def _firwin_ba(*args, **kwargs):
+    if not kwargs.get('pass_zero'):
+        args = (args[0] + 1,) + args[1:]  # numtaps must be odd
+    return scipy.signal.firwin(*args, **kwargs), np.array([1])
+
+
+_BA_FUNCS = {
+    'iir': scipy.signal.iirfilter,
+    'fir': _firwin_ba,
+    }
+
+_ORDER_DEFAULTS = {
+    'iir': 4,
+    'fir': 29,
+    }
+
+class FilteringNaNWarning(Warning):
+    pass
+# always (not just once) show filtering NaN warnings to see the responsible signal
+warnings.filterwarnings('always', category=FilteringNaNWarning)
+
+
+def frequency_filter(darray, f_crit, order=None, irtype='iir', filtfilt=True,
+                     apply_kwargs=None, in_nyq=False, dim=None, **kwargs):
+    """ Applies given frequency filter to a darray.
+    
+    This is a 1-d filter. If the darray is one dimensional, then the dimension
+    along which the filter is applied is chosen automatically if not specified
+    by `dim`. If `darray` is multi dimensional then axis along which the filter
+    is applied has to be specified by `dim` string.
+    
+    The type of the filter is chosen by `irtype` and then `filtfilt` states is
+    the filter is applied both ways, forward and backward. Additional parameters
+    passed to filter function specified by `apply_kwargs`.
+    
+    If 'iir' is chosen as `irtype`, then if `filtfilt` is True then the filter
+    scipy.signal.filtfilt is used, if False scipy.signal.lfilter applies.
+    
+    If 'fir' is chosen as `irtype`, then if `filtfilt` is True then the filter
+    scipy.signal.sosfiltfilt is used, if False scipy.signal.sosfilt applies.
+    
+    Parameters
+    ----------
+    darray : DataArray
+        An xarray type data to be filtered.
+    f_crit : array_like
+        A scalar or length-2 sequence giving the critical frequencies.
+    order : int, optional
+        The order of the filter. If Default then it takes order defaults
+        from `_ORDER_DEFAULTS`, which is `irtype` specific.
+        Default is None.
+    irtype : string, optional
+        A string specifying the impulse response of the filter, has to be 
+        either "fir" then finite impulse response (FIR) is used, or "iir"
+        then infinite impulse response (IIR) filter is applied. ValueError
+        is raised otherwise.
+        Default is "iir".
+    filtfilt: bool, optional
+        When True the filter is applied both forwards and backwards, otherwise
+        only one way, from left to right, is applied.
+        Default is True.
+    apply_kwargs : dict, optional
+        Specifies kwargs, which are passed to the filter function given by
+        `irtype` and `filtfilt`.
+        Default is None.
+    in_nyq : bool, optional
+        If True, then the critical frequencies given by `f_crit` are normalized
+        by Nyquist frequency.
+        Default is False.
+    dim : string, optional
+        A string specifing the dimension along which the filter is applied.
+        If `darray` is 1-d then the dimension is found if not specified by `dim`.
+        For multi dimensional `darray` has to be specified, otherwise ValueError
+        is raised.
+        Default is None.
+    kwargs :
+        Arbitrary keyword arguments passed when the filter is being designed,
+        either to scipy.signal.iirfilter if "iir" method for `irtype` is chosen,
+        or scipy.signal.firwin.            
+    """
+    if irtype not in _BA_FUNCS:
+        raise ValueError('Wrong argument for irtype: {}, must be one of {}'.format(
+            irtype, _BA_FUNCS.keys()))
+    if order is None:
+        order = _ORDER_DEFAULTS[irtype]
+    if apply_kwargs is None:
+        apply_kwargs = {}
+    dim = get_maybe_only_dim(darray, dim)
+    f_crit_norm = np.asarray(f_crit, dtype=np.float)
+    if not in_nyq:              # normalize by Nyquist frequency
+        f_crit_norm *= 2 * get_sampling_step(darray, dim)
+    if np.any(np.isnan(np.asarray(darray))): # only warn since simple forward-filter or FIR is valid
+        warnings.warn('data contains NaNs, filter will propagate them',
+                      FilteringNaNWarning, stacklevel=2)
+    if sosfiltfilt and irtype == 'iir': # TODO merge with other if branch
+        sos = scipy.signal.iirfilter(order, f_crit_norm, output='sos', **kwargs)
+        if filtfilt:
+            ret = xarray.apply_ufunc(sosfiltfilt, sos, darray,
+                                     input_core_dims = [[],[dim]],
+                                     output_core_dims = [[dim]],
+                                     kwargs = apply_kwargs)
+        else:
+            ret = xarray.apply_ufunc(scipy.signal.sosfilt, sos, darray,
+                                     input_core_dims = [[],[dim]],
+                                     output_core_dims = [[dim]],
+                                     kwargs = apply_kwargs)
+    else:
+        b, a = _BA_FUNCS[irtype](order, f_crit_norm, **kwargs)
+        if filtfilt:
+            ret = xarray.apply_ufunc(scipy.signal.filtfilt, b, a, darray,
+                                     input_core_dims = [[],[],[dim]],
+                                     output_core_dims = [[dim]],
+                                     kwargs = apply_kwargs)            
+        else:
+            ret = xarray.apply_ufunc(scipy.signal.lfilter, b, a, darray,
+                                     input_core_dims = [[],[],[dim]],
+                                     output_core_dims = [[dim]],
+                                     kwargs = apply_kwargs)
+    return ret
+
+
+def _update_ftype_kwargs(kwargs, iirvalue, firvalue):
+    if kwargs.get('irtype', 'iir') == 'iir':
+        kwargs.setdefault('btype', iirvalue)
+    else:                       # fir
+        kwargs.setdefault('pass_zero', firvalue)
+    return kwargs
+
+
+def lowpass(darray, f_cutoff, *args, **kwargs):
+    """ Applies lowpass filter to a darray.
+    
+    This is a 1-d filter. If the darray is one dimensional, then the dimension
+    along which the filter is applied is chosen automatically if not specified
+    by an arg `dim`. If `darray` is multi dimensional then axis along which
+    the filter is applied has to be specified by an additional argument `dim`
+    string.
+    
+    Parameters
+    ----------
+    darray : DataArray
+        An xarray type data to be filtered.
+    f_cutoff : array_like
+        A scalar specifying the cut-off frequency for the lowpass filter.
+    args : 
+        Additional arguments passed to frequency_filter function to further
+        specify the filter. The following parameters can be passed:
+        (order, irtype, filtfilt, apply_kwargs, in_nyq, dim)
+    kwargs :
+        Arbitrary keyword arguments passed when the filter is being designed.
+        See frequency_filter documentation for furhter information.
+    """
+    kwargs = _update_ftype_kwargs(kwargs, 'lowpass', True)
+    return frequency_filter(darray, f_cutoff, *args, **kwargs)
+
+
+def highpass(darray, f_cutoff, *args, **kwargs):
+    """ Applies highpass filter to a darray.
+    
+    This is a 1-d filter. If the darray is one dimensional, then the dimension
+    along which the filter is applied is chosen automatically if not specified
+    by an arg `dim`. If `darray` is multi dimensional then axis along which
+    the filter is applied has to be specified by an additional argument `dim`
+    string.
+    
+    Parameters
+    ----------
+    darray : DataArray
+        An xarray type data to be filtered.
+    f_cutoff: array_like
+        A scalar specifying the cut-off frequency for the highpass filter.
+    args : 
+        Additional arguments passed to frequency_filter function to further
+        specify the filter. The following parameters can be passed:
+        (order, irtype, filtfilt, apply_kwargs, in_nyq, dim)
+    kwargs :
+        Arbitrary keyword arguments passed when the filter is being designed.
+        See frequency_filter documentation for furhter information.
+    """
+    kwargs = _update_ftype_kwargs(kwargs, 'highpass', False)
+    return frequency_filter(darray, f_cutoff, *args, **kwargs)
+
+
+def bandpass(darray, f_low, f_high, *args, **kwargs):
+    """ Applies bandpass filter to a darray.
+    
+    This is a 1-d filter. If the darray is one dimensional, then the dimension
+    along which the filter is applied is chosen automatically if not specified
+    by an arg `dim`. If `darray` is multi dimensional then axis along which
+    the filter is applied has to be specified by an additional argument `dim`
+    string.
+    
+    Parameters
+    ----------
+    darray : DataArray
+        An xarray type data to be filtered.
+    f_low : array_like
+        A scalar specifying the lower cut-off frequency for the bandpass filter.
+    f_high : array_like
+        A scalar specifying the higher cut-off frequency for the bandpass filter.
+    args : 
+        Additional arguments passed to frequency_filter function to further
+        specify the filter. The following parameters can be passed:
+        (order, irtype, filtfilt, apply_kwargs, in_nyq, dim)
+    kwargs :
+        Arbitrary keyword arguments passed when the filter is being designed.
+        See frequency_filter documentation for furhter information.
+    """
+    kwargs = _update_ftype_kwargs(kwargs, 'bandpass', False)
+    return frequency_filter(darray, [f_low, f_high], *args, **kwargs)
+
+
+def bandstop(darray, f_low, f_high, *args, **kwargs):
+    """ Applies bandstop filter to a darray.
+    
+    This is a 1-d filter. If the darray is one dimensional, then the dimension
+    along which the filter is applied is chosen automatically if not specified
+    by an arg `dim`. If `darray` is multi dimensional then axis along which
+    the filter is applied has to be specified by an additional argument `dim`
+    string.
+    
+    Parameters
+    ----------
+    darray : DataArray
+        An xarray type data to be filtered.
+    f_low : array_like
+        A scalar specifying the lower cut-off frequency for the bandstop filter.
+    f_high : array_like
+        A scalar specifying the higher cut-off frequency for the bandstop filter.
+    args : 
+        Additional arguments passed to frequency_filter function to further
+        specify the filter. The following parameters can be passed:
+        (order, irtype, filtfilt, apply_kwargs, in_nyq, dim)
+    kwargs :
+        Arbitrary keyword arguments passed when the filter is being designed.
+        See frequency_filter documentation for furhter information.
+    """
+    kwargs = _update_ftype_kwargs(kwargs, 'bandstop', True)
+    return frequency_filter(darray, [f_low, f_high], *args, **kwargs)
+
+
+class DecimationWarning(Warning):
+    pass
+# always (not just once) show decimation warnings to see the responsible signal
+warnings.filterwarnings('always', category=DecimationWarning)
+
+def decimate(darray, q=None, target_fs=None, dim=None, **lowpass_kwargs):
+    '''Decimate signal by given (int) factor or to closest possible target_fs
+    along the specified dimension.
+
+    Decimation: lowpass to new nyquist frequency and then downsample by factor `q`
+    `lowpass_kwargs` are given to the lowpass method.
+
+    If `q` is not given, it is approximated as the closest integer ratio
+    of fs / `target_fs`, so `target_fs` must be smaller than current sampling
+    frequency fs.
+
+    If `q` < 2, decimation is skipped and a DecimationWarning is emitted
+    
+    Parameters
+    ----------
+    darray : DataArray
+        An xarray type data to be decimated.
+    q : array_like
+        A scalar specifying the factor by which the signal should be decimated.
+        If not given, it is approximated as the closest integer ratio of
+        fs / `target_fs`. If set lower than 2, decimation is skipped and
+        a DecimationWarning is emitted.
+        Default is None.
+    target_fs : array_like, optional
+        A scalar specifying target sampling frequency of returning data.
+        Must be smaller than current sampling frequency.
+        Default is None.
+    dim : string, optional
+        A string specifing the dimension along which the filter is applied.
+        If `darray` is 1-d then the dimension is found if not specified by `dim`.
+        For multi dimensional `darray` has to be specified, otherwise ValueError
+        is raised.
+        Default is None.
+    lowpass_kwargs :
+        Arbitrary keyword arguments passed to the lowpass method. See lowpass
+        method for further details.
+    '''
+    dim = get_maybe_only_dim(darray, dim)
+    if q is None:
+        if target_fs is None:
+            raise ValueError('either q or target_fs must be given')
+        dt = get_sampling_step(darray, dim)
+        q = int(np.rint(1.0 / (dt * target_fs)))
+    if q < 2:                   # decimation not possible or useless
+        # show warning at caller level to see which signal it is related to
+        warnings.warn('q factor %i < 2, skipping decimation' % q,
+                      DecimationWarning, stacklevel=2)
+        return darray
+    new_f_nyq = 1.0 / q
+    lowpass_kwargs.setdefault('dim', dim)
+    lowpass_kwargs.setdefault('in_nyq', True)
+    ret = lowpass(darray, new_f_nyq, **lowpass_kwargs)
+    ret = ret.isel(**{dim: slice(None, None, q)})
+    return ret
+
+def savgol_filter(darray, window_length, polyorder, deriv=0, delta=None,
+                  dim=None, mode='interp', cval=0.0):
+    """ Apply a Savitzky-Golay filter to an array.
+
+    This is a 1-d filter.  If `darray` has dimension greater than 1, `dim`
+    determines the dimension along which the filter is applied.
+    Parameters
+    ----------
+    darray : DataArray
+        An xarray type data to be filtered.  If values of `darray` are not
+        a single or double precision floating point array, it will be converted
+        to type ``numpy.float64`` before filtering.
+    window_length : int
+        The length of the filter window (i.e. the number of coefficients).
+        `window_length` must be a positive odd integer. If `mode` is 'interp',
+        `window_length` must be less than or equal to the size of `darray`.
+    polyorder : int
+        The order of the polynomial used to fit the samples.
+        `polyorder` must be less than `window_length`.
+    deriv : int, optional
+        The order of the derivative to compute.  This must be a
+        nonnegative integer.  The default is 0, which means to filter
+        the data without differentiating.
+    delta : float, optional
+        The spacing of the samples to which the filter will be applied.
+        This is only used if deriv > 0.  Default is 1.0.
+    dim : string, optional
+        Specifies the dimension along which the filter is applied. For 1-d 
+        darray finds the only dimension, if not specified. For multi
+        dimensional darray, the dimension for the filtering has to be
+        specified, otherwise raises ValueError.
+        Default is None.
+    mode : str, optional
+        Must be 'mirror', 'constant', 'nearest', 'wrap' or 'interp'.  This
+        determines the type of extension to use for the padded signal to
+        which the filter is applied.  When `mode` is 'constant', the padding
+        value is given by `cval`.  See the Notes for more details on 'mirror',
+        'constant', 'wrap', and 'nearest'.
+        When the 'interp' mode is selected (the default), no extension
+        is used.  Instead, a degree `polyorder` polynomial is fit to the
+        last `window_length` values of the edges, and this polynomial is
+        used to evaluate the last `window_length // 2` output values.
+    cval : scalar, optional
+        Value to fill past the edges of the input if `mode` is 'constant'.
+        Default is 0.0.
+    Returns
+    -------
+    y : DataArray, same shape as `darray`
+        The filtered data.
+    """
+    dim = get_maybe_only_dim(darray, dim)
+    if delta is None:
+        delta = get_sampling_step(darray, dim)
+        window_length = int(np.rint(window_length / delta))
+        if window_length % 2 == 0:  # must be odd
+            window_length += 1
+    return xarray.apply_ufunc(scipy.signal.savgol_filter, darray,
+                              input_core_dims = [[dim]],
+                              output_core_dims = [[dim]],
+                              kwargs=dict(window_length = window_length,
+                                          polyorder = polyorder,
+                                          deriv = deriv, delta = delta,
+                                          mode = mode, cval = cval))
+
+@xarray.register_dataarray_accessor('filt')
+class FilterAccessor(object):
+    '''Accessor exposing common frequency and other filtering methods'''
+
+    def __init__(self, darray):
+        self.darray = darray
+
+    @property
+    def dt(self):
+        '''Sampling step of last axis'''
+        return get_sampling_step(self.darray)
+
+    @property
+    def fs(self):
+        """Sampling frequency in inverse units of self.dt"""
+        return 1.0 / self.dt
+
+    @property
+    def dx(self):
+        '''Sampling steps for all axes as array'''
+        return np.array([get_sampling_step(self.darray, dim) for dim in self.darray.dims])
+
+    # NOTE: the arguments are coded explicitly for tab-completion to work,
+    # using a decorator wrapper with *args would not expose them
+    def low(self, f_cutoff, *args, **kwargs):
+        """Lowpass filter, wraps lowpass"""
+        return lowpass(self.darray, f_cutoff, *args, **kwargs)
+
+    def high(self, f_cutoff, *args, **kwargs):
+        """Highpass filter, wraps highpass"""
+        return highpass(self.darray, f_cutoff, *args, **kwargs)
+
+    def bandpass(self, f_low, f_high, *args, **kwargs):
+        """Bandpass filter, wraps bandpass"""
+        return bandpass(self.darray, f_low, f_high, *args, **kwargs)
+
+    def bandstop(self, f_low, f_high, *args, **kwargs):
+        """Bandstop filter, wraps bandstop"""
+        return bandstop(self.darray, f_low, f_high, *args, **kwargs)
+
+    def freq(self, f_crit, order=None, irtype='iir', filtfilt=True,
+             apply_kwargs=None, in_nyq=False, dim=None, **kwargs):
+        """General frequency filter, wraps frequency_filter"""
+        return frequency_filter(self.darray, f_crit, order, irtype, filtfilt,
+                                apply_kwargs, in_nyq, dim, **kwargs)
+
+    __call__ = freq
+
+    def savgol(self, window_length, polyorder, deriv=0, delta=None,
+                      dim=None, mode='interp', cval=0.0):
+        """Savitzky-Golay filter, wraps savgol_filter"""
+        return savgol_filter(self.darray, window_length, polyorder, deriv, delta,
+                             dim, mode, cval)
+
+    def decimate(self, q=None, target_fs=None, dim=None, **lowpass_kwargs):
+        """Decimate signal, wraps decimate"""
+        return decimate(self.darray, q, target_fs, dim, **lowpass_kwargs)

--- a/xrscipy/signal/spectral.py
+++ b/xrscipy/signal/spectral.py
@@ -450,6 +450,7 @@ def hilbert(darray, N=None, dim=None):
         Analytic signal of the Hilbert transform of 'darray' along selected axis.
     """
     dim = get_maybe_only_dim(darray, dim)
+    axis = darray.get_axis_num(dim)
     n_orig = darray.shape[axis]
     N_unspecified = N is None
     if N_unspecified:
@@ -471,6 +472,6 @@ def _hilbert_wraper(darray, N, n_orig, N_unspecified, axis = -1):
     if n_orig != N and N_unspecified:
         sl = [slice(None)] * out.ndim
         sl[axis] = slice(None, n_orig)
-        out = out[sl]
+        out = out[tuple(sl)]
     return out
 

--- a/xrscipy/signal/spectral.py
+++ b/xrscipy/signal/spectral.py
@@ -1,0 +1,476 @@
+import xarray
+import scipy.signal
+import numpy as np
+try:
+    from scipy.fftpack import next_fast_len
+except ImportError:
+    def next_fast_len(size):
+        return 2**int(np.ceil(np.log2(size)))
+
+from .utils import get_sampling_step, get_maybe_only_dim
+
+_FREQUENCY_DIM = 'frequency'
+
+_DOCSTRING_COMMON_PARAMS = """    fs : float, optional
+        Sampling frequency of the `darray` and `other_darray` (time) series.
+        If not specified, will be calculated it from the sampling step
+        of the specified (or only) dimension.
+    window : str or tuple or array_like, optional
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to a Hann window.
+    seglen : float, optional
+        Segment length (i.e. nperseg) in units of the used (e.g. time) dimension.
+    nperseg : int, optional
+        Length of each segment. Defaults to None, but if window is str or
+        tuple, is set to 256, and if window is array_like, is set to the
+        length of the window.
+    noverlap: int, optional
+        Number of points to overlap between segments. If `None`,
+        ``noverlap = np.rint(nperseg * overlap_ratio)``. Defaults to `None`.
+    overlap_ratio : float, optional
+        Used to calculate noverlap, if it is not specified (see above).
+        Defaults to 0.5.
+    nfft : int, optional
+        Length of the FFT used, if a zero padded FFT is desired. If
+        `None`, the FFT length is `nperseg`. Defaults to `None`.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
+    return_onesided : bool, optional
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Defaults to `True`, but for
+        complex data, a two-sided spectrum is always returned.
+    dim : str, optional
+        Dimension along which the FFT is computed and sampling step calculated.
+        If the signal is 1D, uses the only dimension, otherwise must be specified."""
+
+_DOCSTRING_MODE_PARAM = """mode : str
+        Defines what kind of return values are expected. Options are
+        ['psd', 'complex', 'magnitude', 'angle', 'phase']. 'complex' is
+        equivalent to the output of `stft` with no padding or boundary
+        extension. 'magnitude' returns the absolute magnitude of the
+        STFT. 'angle' and 'phase' return the complex angle of the STFT,
+        with and without unwrapping, respectively."""
+
+_DOCSTRING_SCALING_PARAM = """scaling : { 'density', 'spectrum' }, optional
+        Selects between computing the cross spectral density ('density')
+        where `Pxy` has units of V**2/Hz and computing the cross spectrum
+        ('spectrum') where `Pxy` has units of V**2, if `darray` and `other_darray` are
+        measured in V and `fs` is measured in Hz. Defaults to 'density'.\
+"""
+
+def _add2docstring_common_params(func):
+    if hasattr(func, '__doc__'):
+        func.__doc__ = func.__doc__.format(
+            common_params=_DOCSTRING_COMMON_PARAMS,
+            mode_param=_DOCSTRING_MODE_PARAM,
+            scaling_param=_DOCSTRING_SCALING_PARAM,
+        )
+    return func
+
+
+@_add2docstring_common_params
+def crossspectrogram(darray, other_darray, fs=None, seglen=None,
+                     overlap_ratio=0.5, window='hann', nperseg=256,
+                     noverlap=None, nfft=None, detrend='constant',
+                     return_onesided=True, dim=None, scaling='density',
+                     mode='psd'):
+    """Calculate the cross spectrogram.
+
+    Parameters
+    ----------
+    darray : xarray
+        Series of measurement values
+    other_darray : xarray
+        Series of measurement values
+    {common_params}
+    {scaling_param}
+    {mode_param}
+
+    Returns
+    -------
+    Pxy : xarray.DataArray
+        Cross spectrogram of 'darray' and 'other_darray'
+        with one new dimmension frequency and new coords for the specified dim.
+
+    Notes
+    -----
+    By convention, Pxy is computed with the conjugate FFT of `darray`
+    multiplied by the FFT of `other_darray`.
+    If the input series differ in length, the shorter series will be
+    zero-padded to match.
+    An appropriate amount of overlap will depend on the choice of window
+    and on your requirements. For the default Hann window an overlap of
+    50% is a reasonable trade off between accurately estimating the
+    signal power, while not over counting any of the data. Narrower
+    windows may require a larger overlap.
+
+
+    References
+    ----------
+    .. [1] P. Welch, "The use of the fast Fourier transform for the
+           estimation of power spectra: A method based on time averaging
+           over short, modified periodograms", IEEE Trans. Audio
+           Electroacoust. vol. 15, pp. 70-73, 1967.
+    .. [2] Rabiner, Lawrence R., and B. Gold. "Theory and Application of
+           Digital Signal Processing" Prentice-Hall, pp. 414-419, 1975
+    """
+    dim = get_maybe_only_dim(darray, dim)
+    if fs is None:
+        dt = get_sampling_step(darray, dim)
+        fs = 1.0 / dt
+    else:
+        dt = 1.0 / fs
+    if seglen is not None:
+        nperseg = int(np.rint(seglen / dt))
+        nfft = next_fast_len(nperseg)
+    if noverlap is None:
+        noverlap = np.rint(nperseg * overlap_ratio)
+    if darray is other_darray:
+        d_val = od_val = darray.values
+    else:
+        # outer join align to ensure proper sampling
+        darray, other_darray = xarray.align(darray, other_darray, join='outer',
+                                            copy=False)
+        together = (darray, other_darray)
+        if set(darray.dims) != set(other_darray.dims):
+            together = xarray.broadcast(*together)
+        d_val, od_val = (d.values for d in together)
+
+    # should be the same for other_darray after align
+    axis = darray.get_axis_num(dim)
+    f, t, Pxy = scipy.signal.spectral._spectral_helper(d_val,
+                                                       od_val,
+                                                       fs, window, nperseg,
+                                                       noverlap, nfft, detrend,
+                                                       return_onesided,
+                                                       scaling, axis, mode)
+    t_0 = float(darray.coords[dim][0])
+    t_axis = t + t_0
+    # new dimensions and coordinates construction
+    coord_darr = darray if darray.ndim >= other_darray.ndim else other_darray
+    new_dims = list(coord_darr.dims)
+    # frequency replaces data dim
+    new_dims[new_dims.index(dim)] = _FREQUENCY_DIM
+    new_dims.append(dim)   # make data dim last
+    # select nearest times on other possible coordinates
+    coords_ds = coord_darr.coords.to_dataset()
+    coords_ds = coords_ds.sel(**{dim:t_axis, 'method':'nearest'})
+    coords_ds[dim] = t_axis
+    coords_ds[_FREQUENCY_DIM] = f
+    new_name = 'crossspectrogram_{}_{}'.format(darray.name, other_darray.name)
+    return xarray.DataArray(Pxy, name=new_name,
+                            dims=new_dims, coords=coords_ds.coords)
+
+
+@_add2docstring_common_params
+def csd(darray, other_darray, fs=None, seglen=None, overlap_ratio=0.5,
+        window='hann', nperseg=256, noverlap=None, nfft=None,
+        detrend='constant', return_onesided=True, dim=None, scaling='density',
+        mode='psd'):
+    """
+    Estimate the cross power spectral density, Pxy, using Welch's method.
+
+    Parameters
+    ----------
+    darray : xarray
+        Series of measurement values
+    other_darray : xarray
+        Series of measurement values
+    {common_params}
+    {scaling_param}
+    {mode_param}
+
+    Returns
+    -------
+    Pxy : xarray.DataArray
+        Cross spectral density or cross power spectrum with frequency dimension.
+
+    Notes
+    -----
+    By convention, Pxy is computed with the conjugate FFT of `darray`
+    multiplied by the FFT of `other_darray`.
+    If the input series differ in length, the shorter series will be
+    zero-padded to match.
+    An appropriate amount of overlap will depend on the choice of window
+    and on your requirements. For the default Hann window an overlap of
+    50% is a reasonable trade off between accurately estimating the
+    signal power, while not over counting any of the data. Narrower
+    windows may require a larger overlap.
+
+    References
+    ----------
+    .. [1] P. Welch, "The use of the fast Fourier transform for the
+           estimation of power spectra: A method based on time averaging
+           over short, modified periodograms", IEEE Trans. Audio
+           Electroacoust. vol. 15, pp. 70-73, 1967.
+    .. [2] Rabiner, Lawrence R., and B. Gold. "Theory and Application of
+           Digital Signal Processing" Prentice-Hall, pp. 414-419, 1975
+    """
+    Pxy = crossspectrogram(darray, other_darray, fs, seglen,
+                           overlap_ratio, window, nperseg, noverlap, nfft, detrend,
+                           return_onesided, dim, scaling, mode)
+    dim = get_maybe_only_dim(darray, dim)
+    Pxy = Pxy.mean(dim=dim)
+    Pxy.name = 'csd_{}_{}'.format(darray.name, other_darray.name)
+    return Pxy
+
+
+def freq2lag(darray, is_onesided=False, f_dim=_FREQUENCY_DIM):
+    """
+    Calculate the inverse FFT along the frequency dimension into lag-space
+
+    Parameters
+    ----------
+    darray : xarray.DataArray
+        The result of crossspectral density serves as an input.
+    is_onesided : boolean
+        Indicated whether frequency dimmension is one sided or full.
+        Defaults to 'False'.
+    f_dim : string
+        Defaults to 'frequency'.
+
+    Returns
+    -------
+    ret : xarray
+        Array of 'ret' returned with the main dimmension switched to the time lag.
+    """
+    axis = darray.get_axis_num(f_dim)
+    if is_onesided:
+        ret = xarray.apply_ufunc(np.fft.irfft,darray,
+                                 input_core_dims = [[f_dim]],
+                                 output_core_dims = [[f_dim]])
+        ret = ret.real
+    else:
+        ret = xarray.apply_ufunc(np.fft.ifft,darray,
+                                 input_core_dims = [[f_dim]],
+                                 output_core_dims = [[f_dim]])
+        ret = ret.real    
+    ret.name = 'ifft_' + darray.name
+    f = ret.coords[f_dim]
+    df = f[1] - f[0]
+    dt = 1.0 / (df * darray.shape[axis])
+    lag =  f /df * dt
+    ret.coords['lag'] = lag
+    return ret.swap_dims({f_dim: 'lag'}).isel(lag=lag.argsort().values)
+
+
+@_add2docstring_common_params
+def xcorrelation(darray, other_darray, normalize=True, fs=None, seglen=None,
+                 overlap_ratio=0.5, window='hann', nperseg=256, noverlap=None,
+                 nfft=None, detrend='constant', dim=None):
+    """
+    Calculate the crosscorrelation.
+
+    Parameters
+    ----------
+    darray : xarray
+        Series of measurement values
+    other_darray : xarray
+        Series of measurement values
+    {common_params}
+
+    Returns
+    -------
+    xcorr : xarray
+        Crosscorrelation of 'darray' and 'other_darray'
+        with the given dimension switched to the lag.
+    """
+    csd_d = csd(darray, other_darray, fs, seglen, overlap_ratio, window,
+                nperseg, noverlap, nfft, detrend, return_onesided=False,
+                scaling='spectrum', dim=dim, mode='psd')
+    xcorr = freq2lag(csd_d)
+    if normalize:
+        norm = 1
+        for sig in (darray, other_darray):
+            sig_std = psd(sig, fs, seglen, overlap_ratio, window, nperseg,
+                          noverlap, nfft, detrend, return_onesided=False,
+                          scaling='spectrum', dim=dim, mode='psd').mean(dim=_FREQUENCY_DIM)**0.5
+            norm = norm * sig_std
+        xcorr /= norm
+    return xcorr
+
+
+@_add2docstring_common_params
+def spectrogram(darray, fs=None, seglen=None, overlap_ratio=0.5, window='hann',
+                nperseg=256, noverlap=None, nfft=None, detrend='constant',
+                return_onesided=True, dim=None, scaling='density', mode='psd'):
+    """
+    Calculate the spectrogram using crossspectrogram applied to the same data
+
+    Parameters
+    ----------
+    darray : xarray
+        Series of measurement values
+    {common_params}
+    {scaling_param}
+    {mode_param}
+
+    Returns
+    -------
+    Pxx : xarray.DataArray
+        Spectrogram of 'darray'.
+    """
+    Pxx = crossspectrogram(darray, darray, fs, seglen, overlap_ratio, window,
+                           nperseg, noverlap, nfft, detrend, return_onesided,
+                           dim, scaling, mode)
+    Pxx.name = 'spectrogram_{}'.format(darray.name)
+    return Pxx
+
+
+@_add2docstring_common_params
+def psd(darray, fs=None, seglen=None, overlap_ratio=0.5, window='hann',
+        nperseg=256, noverlap=None, nfft=None, detrend='constant',
+        return_onesided=True, scaling='density', dim=None, mode='psd'):
+    """
+    Calculate the power spectral density.
+
+    Parameters
+    ----------
+    darray : xarray
+        Series of measurement values
+    {common_params}
+    {scaling_param}
+    {mode_param}
+
+    Returns
+    -------
+    Pxx : xarray.DataArray
+        Power spectrum density of 'darray'.
+    """
+    Pxx = spectrogram(darray, fs, seglen, overlap_ratio, window, nperseg,
+                      noverlap, nfft, detrend, return_onesided, dim, scaling,
+                      mode)
+    dim = get_maybe_only_dim(darray, dim)
+    Pxx = Pxx.mean(dim=dim)
+    Pxx.name = 'psd_{}'.format(darray.name)
+    return Pxx
+
+# TODO f_res
+@_add2docstring_common_params
+def coherogram(darray, other_darray, fs=None, seglen=None, overlap_ratio=0.5,
+               nrolling=8, window='hann', nperseg=256, noverlap=None,
+               nfft=None, detrend='constant', return_onesided=True, dim=None):
+    """
+    Calculate the coherogram
+
+    The coherence (i.e. averaging of complex phasors) is done
+    using a rolling average <...> of given size along the FFT windows
+    and then coherogram = <crossspectrogram> / sqrt(<spectrogram1> * <spectrogram2>)
+
+    Parameters
+    ----------
+    darray : xarray
+        Series of measurement values
+    other_darray : xarray
+        Series of measurement values
+    nrolling : int, optional
+            Number of FFT windows used in the rolling average.
+    {common_params}
+
+    Returns
+    -------
+    coh : xarray.DataArray, complex
+        Coherogram of 'darray' and 'other_darray'.
+        It is complex and abs(coh)**2 is the squared magnitude coherohram.
+    """
+    Pxx = spectrogram(darray, fs, seglen, overlap_ratio, window, nperseg,
+                      noverlap, nfft, detrend, return_onesided, dim=dim)
+    Pyy = spectrogram(other_darray, fs, seglen, overlap_ratio, window, nperseg,
+                      noverlap, nfft, detrend, return_onesided, dim=dim)
+    Pxy = crossspectrogram(darray, other_darray, fs, seglen, overlap_ratio,
+                           window, nperseg, noverlap, nfft, detrend,
+                           return_onesided, dim=dim)
+    dim = get_maybe_only_dim(darray, dim)
+    rol_kw = {dim: nrolling, 'center': True}
+    coh = (Pxy.rolling(**rol_kw).mean() /
+           (Pxx.rolling(**rol_kw).mean() * Pyy.rolling(**rol_kw).mean())**0.5)
+    coh.dropna(dim=dim)         # drop nan from averaging edges
+    coh.name = 'coherogram_{}_{}'.format(darray.name, other_darray.name)
+    return coh
+
+
+@_add2docstring_common_params
+def coherence(darray, other_darray, fs=None, seglen=None, overlap_ratio=0.5,
+              window='hann', nperseg=256, noverlap=None, nfft=None,
+              detrend='constant', dim=None):
+    """
+    Calculate the coherence as <CSD> / sqrt(<PSD1> * <PSD2>)
+
+    Parameters
+    ----------
+    darray : xarray
+        Series of measurement values
+    other_darray : xarray
+        Series of measurement values
+    {common_params}
+
+    Returns
+    -------
+    coh : xarray.DataArray, complex
+        Coherence of 'darray' and 'other_darray'.
+        It is complex and abs(coh)**2 is the squared magnitude coherohram.
+    """
+    Pxx = psd(darray, fs, seglen, overlap_ratio, window, nperseg,
+                      noverlap, nfft, detrend, dim=dim)
+    Pyy = psd(other_darray, fs, seglen, overlap_ratio, window, nperseg,
+                      noverlap, nfft, detrend, dim=dim)
+    Pxy = csd(darray, other_darray, fs, seglen, overlap_ratio,
+                           window, nperseg, noverlap, nfft, detrend, dim=dim)
+    coh = Pxy / np.sqrt(Pxx * Pyy)  # magnitude squared coherence
+    coh.name = 'coherence_{}_{}'.format(darray.name, other_darray.name)
+    return coh
+
+
+def hilbert(darray, N=None, dim=None):
+    """
+    Compute the analytic signal, using the Hilbert transform.
+    The transformation is done along the selected dimension.
+
+    Parameters
+    ----------
+    darray : xarray
+        Signal data. Must be real.
+    N : int, optional
+        Number of Fourier components. Defaults to size along dim.
+    dim : string, optional
+        Axis along which to do the transformation.
+        Uses the only dimension of darray is 1D.
+
+    Returns
+    -------
+    darray : xarray
+        Analytic signal of the Hilbert transform of 'darray' along selected axis.
+    """
+    dim = get_maybe_only_dim(darray, dim)
+    n_orig = darray.shape[axis]
+    N_unspecified = N is None
+    if N_unspecified:
+        N = next_fast_len(n_orig)
+    out = xarray.apply_ufunc(_hilbert_wraper, darray,
+                              input_core_dims = [[dim]],
+                              output_core_dims = [[dim]],
+                              kwargs=dict(N = N, n_orig = n_orig, N_unspecified = N_unspecified))
+
+    return out
+
+
+def _hilbert_wraper(darray, N, n_orig, N_unspecified, axis = -1):
+    """
+    Hilbert wraper used to keep the signal dimension length constant
+    """
+    out = scipy.signal.hilbert(np.asarray(darray), N, axis = axis)
+
+    if n_orig != N and N_unspecified:
+        sl = [slice(None)] * out.ndim
+        sl[axis] = slice(None, n_orig)
+        out = out[sl]
+    return out
+

--- a/xrscipy/signal/utils.py
+++ b/xrscipy/signal/utils.py
@@ -1,0 +1,48 @@
+import warnings
+
+
+class UnevenSamplingWarning(Warning):
+    pass
+# always (not just once) show decimation warnings to see the responsible signal
+warnings.filterwarnings('always', category=UnevenSamplingWarning)
+
+def get_maybe_only_dim(darray, dim):
+    """
+    Check the dimension of the signal.
+    
+    Parameters
+    ----------
+    darray : DataArray
+        An xarray DataArray.
+    dim : string
+        Specifies the dimension.
+    """
+    if dim is None:
+        if len(darray.dims) == 1:
+            return darray.dims[0]
+        else:
+            raise ValueError("Specify the dimension")
+    else:
+        return dim
+
+def get_maybe_last_dim_axis(darray, dim=None):
+    if dim is None:
+        axis = darray.ndim-1
+        dim = darray.dims[axis]
+    else:
+        axis = darray.get_axis_num(dim)
+    return dim, axis
+
+
+def get_sampling_step(darray, dim=None, rtol=1e-3):
+    dim = get_maybe_only_dim(darray, dim)
+    
+    coord = darray.coords[dim]
+    dt_avg = float(coord[-1] - coord[0]) / (len(coord) - 1)  # N-1 segments
+    dt_first = float(coord[1] - coord[0])
+
+    if abs(dt_avg - dt_first) > rtol * min(dt_first, dt_avg):
+        # show warning at caller level to see which signal it is related to
+        warnings.warn('Average sampling {:.3g} != first sampling step {:.3g}'.format(
+            dt_avg, dt_first), UnevenSamplingWarning, stacklevel=2)
+    return dt_avg               # should be more precise


### PR DESCRIPTION
Name 'axis' was not defined in function 'hilbert', fixed.
Following FutureWarning was fixed:
spectral.py:475: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  out = out[sl]